### PR TITLE
Fix typo in Sprite effect context

### DIFF
--- a/src/graphic/Sprite.zig
+++ b/src/graphic/Sprite.zig
@@ -539,7 +539,7 @@ pub const Sprite = struct {
         try output_surface.copy(frame.data_surface);
 
         const effect_ctx = movy.render.Effect.RenderEffectContext{
-            .infput_surface = frame_set.frames.items[0].data_surface,
+            .input_surface = frame_set.frames.items[0].data_surface,
             .output_surface = output_surface,
         };
 


### PR DESCRIPTION
## Summary
- fix field name typo in `Sprite.initFromAnsiStr`

## Testing
- `zig build test` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68849570e6708329a7d3de10a68dceec